### PR TITLE
Make script idempotent

### DIFF
--- a/pico_setup.sh
+++ b/pico_setup.sh
@@ -83,7 +83,7 @@ source ~/.bashrc
 
 # Build a couple of examples
 cd "$OUTDIR/pico-examples"
-mkdir build
+mkdir -p build
 cd build
 cmake ../ -DCMAKE_BUILD_TYPE=Debug
 
@@ -102,11 +102,14 @@ for REPO in picoprobe picotool
 do
     DEST="$OUTDIR/$REPO"
     REPO_URL="${GITHUB_PREFIX}${REPO}${GITHUB_SUFFIX}"
-    git clone $REPO_URL
+    if [ ! -d $DEST ]; then
+        git clone $REPO_URL
+    fi
 
     # Build both
+    echo "Building $REPO"
     cd $DEST
-    mkdir build
+    mkdir -p build
     cd build
     cmake ../
     make -j$JNUM


### PR DESCRIPTION
If the script fails on the first try, and is re-run later, it fails for two reasons:
- The `mkdir build` commands fail
- The `git clone` for `picoprobe` and `picotool` fail because those repos have already been cloned.

This PR fixes these issues. This will also supersede/obsolete #6 and fix #10.